### PR TITLE
Update README mock server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ cd medical_app
 Install dependencies
 
 npm install
+Install mock server dependencies (run once)
+
+npm install --prefix mock-server
 Start the development server
 
 npm start
@@ -52,7 +55,9 @@ By default, the app will be running at: http://localhost:3000
 
 Mock JSON Server
 ----------------
-To simulate the backend without MongoDB run the mock server:
+To simulate the backend without MongoDB run the mock server. Make sure you've
+installed its dependencies first by running `npm install --prefix mock-server`
+(you only need to do this once):
 
 ```
 npm run mock-server


### PR DESCRIPTION
## Summary
- clarify that `mock-server` dependencies need installation
- update README instructions for running the mock server

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7ce69c88325b114dde2d44f5eb8