### PR TITLE
Fix local API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ cd medical_app
 Install dependencies
 
 npm install
+Install mock server dependencies (run once)
+
+npm install --prefix mock-server
 Start the development server
 
 npm start
@@ -52,7 +55,9 @@ By default, the app will be running at: http://localhost:3000
 
 Mock JSON Server
 ----------------
-To simulate the backend without MongoDB run the mock server:
+To simulate the backend without MongoDB run the mock server. Make sure you've
+installed its dependencies first by running `npm install --prefix mock-server`
+(you only need to do this once):
 
 ```
 npm run mock-server

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const cors = require('cors');
 const { join } = require('path');
-const { Low, JSONFile } = require('lowdb');
+// lowdb v5+ exposes adapters like JSONFile under the `lowdb/node` entry
+// Using `require('lowdb')` doesn't export JSONFile, so import it from `lowdb/node`
+const { Low } = require('lowdb');
+const { JSONFile } = require('lowdb/node');
 const { nanoid } = require('nanoid');
 
 const app = express();

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
-export const API_URL = window.location.hostname === "localhost" ? "https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/" : "https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/";
-console.log(
-    "API_URL :",
-    API_URL
-);
+export const API_URL =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:8181'
+    : 'https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/';
+
+console.log('API_URL:', API_URL);


### PR DESCRIPTION
## Summary
- update API base URL to use http://localhost:8181 during local dev

## Testing
- `npm install --prefix mock-server`
- `npm run mock-server`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7ce69c88325b114dde2d44f5eb8