### PR TITLE
Add login check for instant consult and notify about booking confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ cd medical_app
 Install dependencies
 
 npm install
+Install mock server dependencies (run once)
+
+npm install --prefix mock-server
 Start the development server
 
 npm start
@@ -52,11 +55,26 @@ By default, the app will be running at: http://localhost:3000
 
 Mock JSON Server
 ----------------
-To simulate the backend without MongoDB run the mock server:
+To simulate the backend without MongoDB run the mock server. Make sure you've
+installed its dependencies first by running `npm install --prefix mock-server`
+(you only need to do this once):
 
 ```
 npm run mock-server
 ```
 
 The mock server listens on port `8181` and stores data in `mock-server/db.json`.
+If you see an `EADDRINUSE` error, another process is already using the port.
+Stop the other server or specify a different port, e.g.
+
+```bash
+# bash/zsh
+PORT=3001 npm run mock-server
+
+# Windows cmd
+set PORT=3001 && npm run mock-server
+
+# PowerShell
+$env:PORT=3001; npm run mock-server
+```
 

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const cors = require('cors');
 const { join } = require('path');
-const { Low, JSONFile } = require('lowdb');
+// lowdb v5+ exposes adapters like JSONFile under the `lowdb/node` entry
+// Using `require('lowdb')` doesn't export JSONFile, so import it from `lowdb/node`
+const { Low } = require('lowdb');
+const { JSONFile } = require('lowdb/node');
 const { nanoid } = require('nanoid');
 
 const app = express();
@@ -67,6 +70,17 @@ app.put('/api/auth/user', async (req, res) => {
   res.json({ authtoken: 'mock-token', user });
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Mock server running on port ${PORT}`);
+});
+
+server.on('error', (err) => {
+  if (err.code === 'EADDRINUSE') {
+    console.error(
+      `Port ${PORT} is already in use. Set the PORT env variable to use a different port.`
+    );
+    process.exit(1);
+  } else {
+    throw err;
+  }
 });

--- a/src/Components/BookingConsultation/AppointmentForm.css
+++ b/src/Components/BookingConsultation/AppointmentForm.css
@@ -7,3 +7,9 @@
     margin: 25px;
     border-radius: 10px;
 }
+
+.confirmation-note {
+    font-size: 14px;
+    margin-bottom: 15px;
+    color: #555;
+}

--- a/src/Components/BookingConsultation/AppointmentForm.js
+++ b/src/Components/BookingConsultation/AppointmentForm.js
@@ -34,6 +34,10 @@ const AppointmentForm = ({ onSubmit }) => {
   
     return (
       <form onSubmit={handleFormSubmit} className="appointment-form">
+        <p className="confirmation-note">
+          Your booking request will be confirmed by our team. You will be
+          notified once it is approved.
+        </p>
         <div className="form-group">
           <label htmlFor="name">Name:</label>
           <input

--- a/src/Components/InstantConsultationBooking/InstantConsultation.js
+++ b/src/Components/InstantConsultationBooking/InstantConsultation.js
@@ -44,6 +44,13 @@ const InstantConsultation = () => {
 
     const navigate = useNavigate();
 
+    // Redirect unauthenticated users to login
+    useEffect(() => {
+        if (!sessionStorage.getItem('auth-token')) {
+            navigate('/login');
+        }
+    }, [navigate]);
+
     useEffect(() => {
         getDoctorsDetails(); // No longer re-created on every render
     }, [getDoctorsDetails]); // This makes the effect dependent on getDoctorsDetails

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
-export const API_URL = window.location.hostname === "localhost" ? "https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/" : "https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/";
-console.log(
-    "API_URL :",
-    API_URL
-);
+export const API_URL =
+  window.location.hostname === 'localhost'
+    ? 'http://localhost:8181'
+    : 'https://leecoombes-8181.theiadockernext-0-labs-prod-theiak8s-4-tor01.proxy.cognitiveclass.ai/';
+
+console.log('API_URL:', API_URL);


### PR DESCRIPTION
## Summary
- restrict Instant Consultation page to logged-in users
- notify users that Book Appointment requests require confirmation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7ce69c88325b114dde2d44f5eb8